### PR TITLE
add missing close brackets to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ server <- function(input, output) {
     observeEvent(input$clipbtn, clipr::write_clip(input$copytext))
   }
   
+  })
 }
 
 shinyApp(ui = ui, server = server)


### PR DESCRIPTION
The example in the README.md is missing a couple of brackets, just added them in :)